### PR TITLE
Updated ASCII-Video logic to avoid out of memory issue when processing large videos

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,7 +72,7 @@ program
         });
 
         lineReader.on('line', line => {
-            const frame = yaml.safeLoad(line);
+            const frame = yaml.safeLoad(line)[0];
             const frameRate = (opts && opts.frame_rate) ? opts.frame_rate : 155;
 
             setTimeout(() => logUpdate(frame), frameRate);

--- a/main.js
+++ b/main.js
@@ -66,20 +66,17 @@ program
     .description('Plays back a generated sprite file')
     .option('-f, --frame_rate <rate>', 'A number which specifies the rate at which to iterate through the sprites')
     .action((pathToFile, opts) => {
-        console.log(pathToFile)
-        readFile(pathToFile)
-            .then((data) => {
-                let i = 0;
-                const frames = JSON.parse(data);
-                const frameRate = (opts && opts.frame_rate) ? opts.frame_rate : 155;
+        console.log(pathToFile);
+        const lineReader = require('readline').createInterface({
+            input: require('fs').createReadStream(pathToFile)
+        });
 
-                setInterval(() => {
-                    logUpdate(frames[i]);
-                    (i < frames.length - 1)
-                        ? i++
-                        : i = 0
-                }, frameRate);
-            });
+        lineReader.on('line', line => {
+            const frame = yaml.safeLoad(line);
+            const frameRate = (opts && opts.frame_rate) ? opts.frame_rate : 155;
+
+            setTimeout(() => logUpdate(frame), frameRate);
+        });
     });
 
 program.parse(process.argv);
@@ -118,7 +115,7 @@ function createSprites(files, outputTo, idx, sprites) {
 }
 
 function appendToFile(outputTo, sprites) {
-    const outFile = yaml.dump(sprites);
+    const outFile = yaml.safeDump(sprites);
 
     fs.appendFile(outputTo, outFile, (err) => {
         if (err) return console.log(warningMsg(err));

--- a/main.js
+++ b/main.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node --harmony
-'use strict'; 
+'use strict';
 
 /*=====================================================
                     IMPORTS / SETUP
 ======================================================*/
-const _            = require('lodash');
-const fs           = require('fs');
-const clc          = require('cli-color');
-const shell        = require('shelljs');
-const program      = require('commander');
-const logUpdate    = require('log-update');
+const _ = require('lodash');
+const fs = require('fs');
+const clc = require('cli-color');
+const shell = require('shelljs');
+const program = require('commander');
+const logUpdate = require('log-update');
 const imageToAscii = require("image-to-ascii");
 
 const tmpDirPath = '/tmp/__sprite_cli_output/';
@@ -18,128 +18,141 @@ const tmpDirPath = '/tmp/__sprite_cli_output/';
                           MAIN
 ======================================================*/
 program
-  .version('0.0.4')
-  .command('create <input-video> <output-filename>')
-  .description('Takes an input video, converts it into ASCII frames, and writes it to an output file.')
-  .action((video, outputTo) => {
-    if(!_.endsWith(outputTo, '.js')) {
-      return console.log(errMsg('The outputfile must be a Javascript file.'));
-    }
+    .version('0.0.4')
+    .command('create <input-video> <output-filename>')
+    .description('Takes an input video, converts it into ASCII frames, and writes it to an output file.')
+    .action((video, outputTo) => {
+        if (!_.endsWith(outputTo, '.js')) {
+            return console.log(errMsg('The outputfile must be a Javascript file.'));
+        }
 
-    const dir             = process.cwd();
-    const finishLoadingId = showLoading();
-    
-    // make temp directory to write image files to
-    shell.exec(`cd /tmp && mkdir __sprite_cli_output && cd ${dir}`);
+        const dir = process.cwd();
+        const finishLoadingId = showLoading();
 
-    if (shell.exec(`ffmpeg -i ${program.args[0]} ${tmpDirPath}image%d.jpg`).code !== 0) {
-      // stop loading animation
-      clearInterval(finishLoadingId);
-      return console.log(errMsg('@todo: error message for shit went wrong.'))
-    }
+        // make temp directory to write image files to
+        shell.exec(`cd /tmp && mkdir __sprite_cli_output && cd ${dir}`);
 
-    // stop loading animation
-    clearInterval(finishLoadingId);
+        if (shell.exec(`ffmpeg -i ${program.args[0]} ${tmpDirPath}image%d.jpg`).code !== 0) {
+            // stop loading animation
+            clearInterval(finishLoadingId);
+            return console.log(errMsg('@todo: error message for shit went wrong.'))
+        }
 
-    // ensure frames are in correct order
-    const files = fs.readdirSync(tmpDirPath).sort((f1, f2) => {
-      try {
-        const fileOne = parseInt(f1.match(/\d/g).join(''));
-        const fileTwo = parseInt(f2.match(/\d/g).join(''));
-        return fileTwo - (fileOne + 1);
-      } catch(e) {
-        return 0
-      }
-    }).reverse();
+        // stop loading animation
+        clearInterval(finishLoadingId);
 
-    createSprites(files, outputTo, 0 , []);
-  });
+        // ensure frames are in correct order
+        const files = fs.readdirSync(tmpDirPath).sort((f1, f2) => {
+            try {
+                const fileOne = parseInt(f1.match(/\d/g).join(''));
+                const fileTwo = parseInt(f2.match(/\d/g).join(''));
+                return fileTwo - (fileOne + 1);
+            } catch (e) {
+                return 0
+            }
+        }).reverse();
+
+        createSprites(files, outputTo, 0, []);
+    });
 
 program
-  .command('play <file>')
-  .description('Plays back a generated sprite file')
-  .option('-f, --frame_rate <rate>', 'A number which specifies the rate at which to iterate through the sprites')
-  .action((pathToFile, opts) => {
-    console.log(pathToFile)
-    readFile(pathToFile)
-    .then((data) => {
-      let i = 0;
-      const frames    = JSON.parse(data);
-      const frameRate = (opts && opts.frame_rate) ? opts.frame_rate : 155;
+    .command('play <file>')
+    .description('Plays back a generated sprite file')
+    .option('-f, --frame_rate <rate>', 'A number which specifies the rate at which to iterate through the sprites')
+    .action((pathToFile, opts) => {
+        console.log(pathToFile)
+        readFile(pathToFile)
+            .then((data) => {
+                let i = 0;
+                const frames = JSON.parse(data);
+                const frameRate = (opts && opts.frame_rate) ? opts.frame_rate : 155;
 
-      setInterval(() => {
-        logUpdate(frames[i]);
-        (i < frames.length - 1)
-          ? i++
-          : i = 0
-      }, frameRate);
+                setInterval(() => {
+                    logUpdate(frames[i]);
+                    (i < frames.length - 1)
+                        ? i++
+                        : i = 0
+                }, frameRate);
+            });
     });
-  });
- 
+
 program.parse(process.argv);
-if(!program.args.length) program.help();
+if (!program.args.length) program.help();
 
 /*=====================================================
                         HELPERS
 ======================================================*/
-function createSprites(files, outputTo, idx, output) {
-  if(idx === files.length) {
-    const outFile = JSON.stringify(output);
-      
-    fs.writeFile(outputTo, outFile, (err) => {
-      if(err) return console.log(warningMsg(err));
+function createSprites(files, outputTo, idx, sprites) {
+    if (idx === files.length) {
+        appendToFile(outputTo, sprites, true);
+    } else {
+        imageToAscii(tmpDirPath + files[idx], {
+            image_type: 'jpg'
+        }, (err, converted) => {
+            if (err) {
+                console.log(warningMsg(err));
+            } else {
+                sprites.push(converted);
 
-      // clean up temp directory after .js file has been written
-      shell.exec(`rm -rf ${tmpDirPath}`)
-      return console.log(infoMsg(`File written to ${outputTo}`));
-    });
-  } else {
-    imageToAscii(tmpDirPath + files[idx], {
-      image_type: 'jpg'
-    }, (err, converted) => {
-      if(err) {
-        console.log(warningMsg(err));
-      } else {
-        output.push(converted);
-        logUpdate(`Creating sprites: ${Math.round((idx / files.length) * 100)}%`);
-      }
+                // write to disk before sprites array gets too large
+                if (sprites.length > 500) {
+                    appendToFile(outputTo, sprites);
+                    sprites = [];
+                }
 
-      createSprites(files, outputTo, idx + 1, output);
+                logUpdate(`Creating sprites: ${Math.round((idx / files.length) * 100)}%`);
+            }
+
+            createSprites(files, outputTo, idx + 1, sprites);
+        });
+    }
+}
+
+function appendToFile(outputTo, sprites, isLastWrite = false) {
+    const outFile = JSON.stringify(sprites);
+
+    fs.appendFile(outputTo, outFile, (err) => {
+        if (err) return console.log(warningMsg(err));
+
+        // clean up temp directory if this is the last chunk of sprites to append
+        if (isLastWrite) {
+            shell.exec(`rm -rf ${tmpDirPath}`);
+            console.log(infoMsg(`File written to ${outputTo}`));
+        }
     });
-  }
 }
 
 function showLoading() {
-  const frames = ['-', '\\', '|', '/'];
-  let i = 0;
+    const frames = ['-', '\\', '|', '/'];
+    let i = 0;
 
-  return setInterval(() => {
-    const frame = frames[i = ++i % frames.length];
-    logUpdate(`${frame} Converting video to frames ${frame}`);
-  }, 80)
+    return setInterval(() => {
+        const frame = frames[i = ++i % frames.length];
+        logUpdate(`${frame} Converting video to frames ${frame}`);
+    }, 80)
 }
 
 function readFile(pathTo) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(pathTo, (err, data) => {
-      if(!err) return resolve(data);
-      console.log(err);
-      reject(err);
-    })
-  });
+    return new Promise((resolve, reject) => {
+        fs.readFile(pathTo, (err, data) => {
+            if (!err) return resolve(data);
+            console.log(err);
+            reject(err);
+        })
+    });
 }
 
 function infoMsg(msg) {
-  const infoColor = clc.xterm(33);
-  return infoColor(msg);
+    const infoColor = clc.xterm(33);
+    return infoColor(msg);
 }
 
 function errMsg(msg) {
-  const errColor = clc.xterm(9);
-  return errColor(msg);
+    const errColor = clc.xterm(9);
+    return errColor(msg);
 }
 
 function warningMsg(msg) {
-  const warningColor = clc.xterm(214);
-  return warningColor(msg);
+    const warningColor = clc.xterm(214);
+    return warningColor(msg);
 }

--- a/main.js
+++ b/main.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node --harmony
-'use strict';
 
 /*=====================================================
                     IMPORTS / SETUP

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ascii-video",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A tool to create and play sprite animation in the terminal",
   "main": "./main.js",
   "repository": {
@@ -26,6 +26,7 @@
     "commander": "^2.9.0",
     "gm": "^1.23.0",
     "image-to-ascii": "^3.0.5",
+    "js-yaml": "^3.10.0",
     "lodash": "^4.17.4",
     "log-update": "^1.0.2",
     "paralleljs": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "js-yaml": "^3.10.0",
     "lodash": "^4.17.4",
     "log-update": "^1.0.2",
-    "paralleljs": "^0.2.1",
     "shelljs": "^0.7.7"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
     "image-to-ascii": "^3.0.5",
     "lodash": "^4.17.4",
     "log-update": "^1.0.2",
+    "paralleljs": "^0.2.1",
     "shelljs": "^0.7.7"
+  },
+  "engines": {
+    "node": "6.10.0",
+    "npm": "4.0.5"
   }
 }


### PR DESCRIPTION
Hey Justin,

I came across your ASCII-Video tool and really loved it! While I was playing with it, I found the script was throwing out of memory exceptions when I asked it to handle a relatively larger video (8MB). I found the the issue was caused by keeping all converted ascii sprites in memory. I made some changes to progressively write results into the output file to make this problem to go away. I'd like to get a review from you :)

The diff might look large because my IDE auto reformatted your original script, I can change that back if you want. The actual diff is pretty small.

I'm very new to Github and it is my first pull request. I'm sure there are things I didn't do correctly. Please feel free to let me know any suggestions and feedback. Thank you very much!

Regards,
Xinyi